### PR TITLE
fixed memory leaks

### DIFF
--- a/fmmr-library/jni/metadata/wseemann_media_MediaMetadataRetriever.cpp
+++ b/fmmr-library/jni/metadata/wseemann_media_MediaMetadataRetriever.cpp
@@ -208,7 +208,7 @@ static void wseemann_media_FFmpegMediaMetadataRetriever_setDataSourceFD(JNIEnv *
 
 static jbyteArray wseemann_media_FFmpegMediaMetadataRetriever_getFrameAtTime(JNIEnv *env, jobject thiz, jlong timeUs, jint option)
 {
-   //__android_log_write(ANDROID_LOG_INFO, LOG_TAG, "getFrameAtTime");
+   __android_log_write(ANDROID_LOG_INFO, LOG_TAG, "getFrameAtTime");
    MediaMetadataRetriever* retriever = getRetriever(env, thiz);
    if (retriever == 0) {
        jniThrowException(env, "java/lang/IllegalStateException", "No retriever available");
@@ -216,7 +216,7 @@ static jbyteArray wseemann_media_FFmpegMediaMetadataRetriever_getFrameAtTime(JNI
    }
 
    AVPacket packet;
-   av_init_packet(&packet);
+   //av_init_packet(&packet);
    jbyteArray array = NULL;
 
    if (retriever->getFrameAtTime(timeUs, option, &packet) == 0) {
@@ -232,10 +232,11 @@ static jbyteArray wseemann_media_FFmpegMediaMetadataRetriever_getFrameAtTime(JNI
         	   memcpy(bytes, data, size);
                env->ReleaseByteArrayElements(array, bytes, 0);
            }
+           //env->DeleteLocalRef(array);
        }
+       av_free_packet(&packet);
    }
 
-   av_free_packet(&packet);
    
    return array;
 }


### PR DESCRIPTION
Hey man, I dug a little deeper and found a couple of possible memory leaks, and one definite one (stopped my app crashing once I changed it). The issue seemed to be that you were allocating the frame, then re-allocating the same pointer as a picture in convert_image. 

Anyway, works for me, but it's not particularly tested. Might be a slight performance improvement too?
