### PR TITLE
Add audio stream metadata: sample rate, bit depth, channel count, bitrate

### DIFF
--- a/core/src/main/java/wseemann/media/FFmpegMediaMetadataRetriever.java
+++ b/core/src/main/java/wseemann/media/FFmpegMediaMetadataRetriever.java
@@ -735,6 +735,23 @@ public class FFmpegMediaMetadataRetriever
      * The metadata key to retrieve the video height.
      */
     public static final String METADATA_KEY_VIDEO_HEIGHT = "video_height";
+    /**
+     * The metadata key to retrieve the audio sample rate in Hz.
+     */
+    public static final String METADATA_KEY_SAMPLE_RATE = "sample_rate";
+    /**
+     * The metadata key to retrieve the number of bits per audio sample.
+     * May be 0 for formats that do not signal bit depth (e.g. AAC, MP3).
+     */
+    public static final String METADATA_KEY_BITS_PER_SAMPLE = "bits_per_sample";
+    /**
+     * The metadata key to retrieve the number of audio channels.
+     */
+    public static final String METADATA_KEY_CHANNEL_COUNT = "channel_count";
+    /**
+     * The metadata key to retrieve the audio stream bitrate in bits per second.
+     */
+    public static final String METADATA_KEY_AUDIO_BITRATE = "audio_bitrate";
 
     /**
      Class to hold the media's metadata.  Metadata are used

--- a/native/src/main/jni/metadata/ffmpeg_mediametadataretriever.c
+++ b/native/src/main/jni/metadata/ffmpeg_mediametadataretriever.c
@@ -278,6 +278,7 @@ int set_data_source_l(State **ps, const char* path) {
     set_filesize(state->pFormatCtx);
     set_chapter_count(state->pFormatCtx);
     set_video_dimensions(state->pFormatCtx, state->video_st);
+    set_audio_properties(state->pFormatCtx, state->audio_st);
     
 	/*printf("Found metadata\n");
 	AVDictionaryEntry *tag = NULL;

--- a/native/src/main/jni/metadata/ffmpeg_utils.c
+++ b/native/src/main/jni/metadata/ffmpeg_utils.c
@@ -131,6 +131,32 @@ void set_video_dimensions(AVFormatContext *ic, AVStream *video_st) {
 	}
 }
 
+void set_audio_properties(AVFormatContext *ic, AVStream *audio_st) {
+	char value[30] = "0";
+
+	if (audio_st && audio_st->codecpar) {
+		sprintf(value, "%d", audio_st->codecpar->sample_rate);
+		av_dict_set(&ic->metadata, SAMPLE_RATE, value, 0);
+
+		int bps = audio_st->codecpar->bits_per_raw_sample;
+		if (bps == 0) {
+			bps = audio_st->codecpar->bits_per_coded_sample;
+		}
+		sprintf(value, "%d", bps);
+		av_dict_set(&ic->metadata, BITS_PER_SAMPLE, value, 0);
+
+		sprintf(value, "%d", audio_st->codecpar->ch_layout.nb_channels);
+		av_dict_set(&ic->metadata, CHANNEL_COUNT, value, 0);
+
+		int64_t bitrate = audio_st->codecpar->bit_rate;
+		if (bitrate == 0) {
+			bitrate = ic->bit_rate;
+		}
+		sprintf(value, "%lld", (long long) bitrate);
+		av_dict_set(&ic->metadata, AUDIO_BITRATE, value, 0);
+	}
+}
+
 const char* extract_metadata_internal(AVFormatContext *ic, AVStream *audio_st, AVStream *video_st, const char* key) {
     char* value = NULL;
     

--- a/native/src/main/jni/metadata/ffmpeg_utils.h
+++ b/native/src/main/jni/metadata/ffmpeg_utils.h
@@ -37,6 +37,10 @@ static const char *CHAPTER_COUNT = "chapter_count";
 static const char *FILESIZE = "filesize";
 static const char *VIDEO_WIDTH = "video_width";
 static const char *VIDEO_HEIGHT = "video_height";
+static const char *SAMPLE_RATE = "sample_rate";
+static const char *BITS_PER_SAMPLE = "bits_per_sample";
+static const char *CHANNEL_COUNT = "channel_count";
+static const char *AUDIO_BITRATE = "audio_bitrate";
 
 static const int SUCCESS = 0;
 static const int FAILURE = -1;
@@ -49,6 +53,7 @@ void set_framerate(AVFormatContext *ic, AVStream *audio_st, AVStream *video_st);
 void set_filesize(AVFormatContext *ic);
 void set_chapter_count(AVFormatContext *ic);
 void set_video_dimensions(AVFormatContext *ic, AVStream *video_st);
+void set_audio_properties(AVFormatContext *ic, AVStream *audio_st);
 const char* extract_metadata_internal(AVFormatContext *ic, AVStream *audio_st, AVStream *video_st, const char* key);
 int get_metadata_internal(AVFormatContext *ic, AVStream *audio_st, AVStream *video_st, AVDictionary **metadata);
 const char* extract_metadata_from_chapter_internal(AVFormatContext *ic, AVStream *audio_st, AVStream *video_st, const char* key, int chapter);    


### PR DESCRIPTION
Add four audio stream properties that Android's `MediaMetadataRetriever` provides but `FFmpegMediaMetadataRetriever` doesn't:
* `METADATA_KEY_SAMPLE_RATE` — from `codecpar->sample_rate`
* `METADATA_KEY_BITS_PER_SAMPLE` — from `bits_per_raw_sample`, falling back to `bits_per_coded_sample` for lossy formats like MP3
* `METADATA_KEY_CHANNEL_COUNT` — from `codecpar->ch_layout.nb_channels`
* `METADATA_KEY_AUDIO_BITRATE` — from `codecpar->bit_rate`, falling back to `ic->bit_rate` for container-level bitrate

